### PR TITLE
fix: adicionar CSRF aos formulários para resolver erro 403 (closes #2)

### DIFF
--- a/src/main/resources/templates/cadastro/cadastro.html
+++ b/src/main/resources/templates/cadastro/cadastro.html
@@ -11,54 +11,53 @@
 	src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
-
-<h2>Cadastro de usuarios</h2>
-
-<form action="/salvarUsuario" method="post" onsubmit="return validarCampos() ? true : false">
-	<div class="row">
-		<div class="input-field col s6">
-			<label for="login" class="active">Login</label>
-			<input id="login" name="login" type="text" class="validate;">
+	<h2>Cadastro de usuarios</h2>
+	<form action="/salvarUsuario" method="post" onsubmit="return validarCampos() ? true : false">
+		<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+		<div class="row">
+			<div class="input-field col s6">
+				<label for="login" class="active">Login</label>
+				<input id="login" name="login" type="text" class="validate;">
+			</div>
 		</div>
-	</div>
-	<div class="row">
-		<div class="input-field col s6">
-			<label for="senha" class="active">Senha</label>
-			<input id="senha" name="senha" type="password" class="validate">
+		<div class="row">
+			<div class="input-field col s6">
+				<label for="senha" class="active">Senha</label>
+				<input id="senha" name="senha" type="password" class="validate">
+			</div>
 		</div>
-	</div>
-	<div class="row">
-		<div class="input-field col s6">
-			<label for="senhaConfirma" class="active">Confirme a senha</label>
-			<input id="senhaConfirma" name="senhaConfirma" type="password" class="validate">
+		<div class="row">
+			<div class="input-field col s6">
+				<label for="senhaConfirma" class="active">Confirme a senha</label>
+				<input id="senhaConfirma" name="senhaConfirma" type="password" class="validate">
+			</div>
 		</div>
-	</div>
-	<div id="mensagemErro" th:text="${mensagemErro}" style="color: red"></div>
-	<div class="row">
-	  	<div class="input-field col s6">
-			<input class="waves-effect waves-light btn" type="submit" value="Salvar">
-		</div>
-  	</div>
-</form>
-<script type="text/javascript">
-	function validarCampos(){
-		const login = document.getElementById('login').value.trim();
-		const senha =  document.getElementById('senha').value.trim();
-		const senhaConfirma =  document.getElementById('senhaConfirma').value.trim();
-	  	const mensagemErro = document.getElementById('mensagemErro');
-		
-	  	//not null
-	  	if(login == '' || senha == '' || senhaConfirma == ''){
-	  		mensagemErro.innerHTML= "Todos os campos devem ser preenchidos";
-	  		return false;
-	  	}
-	  	
-	  	if(!(senha === senhaConfirma)){
-	  		mensagemErro.innerHTML= "As senhas devem ser iguais";
-	  		return false;
-	  	}
-	return true;
-	}
-</script>
+		<div id="mensagemErro" th:text="${mensagemErro}" style="color: red"></div>
+		<div class="row">
+		  	<div class="input-field col s6">
+				<input class="waves-effect waves-light btn" type="submit" value="Salvar">
+			</div>
+	  	</div>
+	</form>
+	<script type="text/javascript">
+		function validarCampos(){
+			const login = document.getElementById('login').value.trim();
+			const senha =  document.getElementById('senha').value.trim();
+			const senhaConfirma =  document.getElementById('senhaConfirma').value.trim();
+		  	const mensagemErro = document.getElementById('mensagemErro');
+			
+		  	//not null
+		  	if(login == '' || senha == '' || senhaConfirma == ''){
+		  		mensagemErro.innerHTML= "Todos os campos devem ser preenchidos";
+		  		return false;
+		  	}
+		  	
+		  	if(!(senha === senhaConfirma)){
+		  		mensagemErro.innerHTML= "As senhas devem ser iguais";
+		  		return false;
+		  	}
+		return true;
+		}
+	</script>
 </body>
 </html>

--- a/src/main/resources/templates/gerador-cpf/gerador-cpf.html
+++ b/src/main/resources/templates/gerador-cpf/gerador-cpf.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
-	xmlns:th="http://www.thymeleaf.org">
+	  xmlns:th="http://www.thymeleaf.org"
+	  xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <head>
 <meta charset="UTF-8">
 <title>Gerador CPF</title>
@@ -16,9 +17,10 @@
 		<div class="titulo">
 			<h1>Gerador de CPF</h1>
 		</div>
-		<br> <br>
+		<br><br>
 		<form action="/gerar-cpf-aleatorio" onsubmit="return validarCampos() ? true : false" 
 			method="post" class="col s12">
+			<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
 			<div id="mensagemErro" th:text="${msgErro}" style="color: red;"></div>
 			<div id="mensagemValido" th:text="${msgvalido}" style="color: green;"></div>
 			<div class="row cpfale">
@@ -26,7 +28,6 @@
 					<label for="cpf" class="active">Gerar CPF aleátorio</label> 
 					<input id="cpf" name="cpf" th:value="${cpf}">
 				</div>
-
 				<div class="input-field col s6">
 					<label for="uf" class="active">Escolha o Estado</label> <select
 						id="uf" name="uf">


### PR DESCRIPTION
**Descrição do problema**  
Ao tentar submeter um formulário, a aplicação retorna um erro HTTP 403 Forbidden, exibindo a página padrão de erro do Spring Boot (Whitelabel Error Page).

**Causa identificada**  
O erro acontece porque o formulário não possui o token CSRF exigido pelo Spring Security para requisições do formulário.

**Passos para reproduzir**
1. Acessar a página com o formulário ( Cadastro ou gerador de CPF)
2. Submeter o formulário
3. Observar o erro 403 na resposta

**Comportamento esperado**  
A requisição deveria ser processada normalmente se o token CSRF estiver presente.

**Solução sugerida**  
Adicionar o Token CSRF ao formulário.  
incluir:

```html
<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>