### PR TITLE
fix: adicionar CSRF aos formulários para resolver erro 403 (closes #4)

### DIFF
--- a/src/main/resources/templates/cadastro/cadastro.html
+++ b/src/main/resources/templates/cadastro/cadastro.html
@@ -15,6 +15,7 @@
 <h2>Cadastro de usuarios</h2>
 
 <form action="/salvarUsuario" method="post" onsubmit="return validarCampos() ? true : false">
+	<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
 	<div class="row">
 		<div class="input-field col s6">
 			<label for="login" class="active">Login</label>

--- a/src/main/resources/templates/gerador-cpf/gerador-cpf.html
+++ b/src/main/resources/templates/gerador-cpf/gerador-cpf.html
@@ -19,6 +19,7 @@
 		<br> <br>
 		<form action="/gerar-cpf-aleatorio" onsubmit="return validarCampos() ? true : false" 
 			method="post" class="col s12">
+			<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
 			<div id="mensagemErro" th:text="${msgErro}" style="color: red;"></div>
 			<div id="mensagemValido" th:text="${msgvalido}" style="color: green;"></div>
 			<div class="row cpfale">


### PR DESCRIPTION
**Descrição do problema**  
Ao tentar submeter um formulário, a aplicação retorna um erro HTTP 403 Forbidden, exibindo a página padrão de erro do Spring Boot (Whitelabel Error Page).

**Causa identificada**  
O erro acontece porque o formulário não possui o token CSRF exigido pelo Spring Security para requisições do formulário.

**Passos para reproduzir**
1. Acessar a página com o formulário ( Cadastro ou gerador de CPF)
2. Submeter o formulário
3. Observar o erro 403 na resposta

**Comportamento esperado**  
A requisição deveria ser processada normalmente se o token CSRF estiver presente.

**Solução sugerida**  
Adicionar o Token CSRF ao formulário.  
incluir:

```html
<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>