### PR TITLE
refactor(cpf): extrair CpfResultDTO e centralizar processamento de CPF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,34 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.4.4</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath />
 	</parent>
+
 	<groupId>br.com.sodresoftwares</groupId>
 	<artifactId>geradorcpf</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>geradorcpf</name>
-	<description>Demo project for Spring Boot</description>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
+
 	<properties>
 		<java.version>21</java.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -39,8 +31,8 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
-		    <groupId>org.springframework.boot</groupId>
-		    <artifactId>spring-boot-starter-data-jpa</artifactId>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -59,16 +51,25 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-		    <groupId>org.springframework.boot</groupId>
-		    <artifactId>spring-boot-starter-security</artifactId>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
 		<dependency>
-		    <groupId>org.thymeleaf.extras</groupId>
-		    <artifactId>thymeleaf-extras-springsecurity6</artifactId>
+			<groupId>org.thymeleaf.extras</groupId>
+			<artifactId>thymeleaf-extras-springsecurity6</artifactId>
 		</dependency>
 	</dependencies>
+
 	<build>
 		<plugins>
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>3.3.1</version>
+				<configuration>
+					<encoding>UTF-8</encoding>
+				</configuration>
+			</plugin>
+
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/src/main/java/br/com/sodresoftwares/geradorcpf/controller/GeradorCpfController.java
+++ b/src/main/java/br/com/sodresoftwares/geradorcpf/controller/GeradorCpfController.java
@@ -1,13 +1,12 @@
 package br.com.sodresoftwares.geradorcpf.controller;
 
-import java.util.Map;
-
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import br.com.sodresoftwares.geradorcpf.model.CpfResultDTO;
 import br.com.sodresoftwares.geradorcpf.service.GeradorCpfService;
 
 @Controller
@@ -29,25 +28,11 @@ public class GeradorCpfController {
 									@RequestParam("acao")String acao, @RequestParam("uf")String uf,
 									@RequestParam("pontuacao") String pontuacao,
 									@RequestParam("cpf")String cpfDigitado) {
-		String cpf;
-		if(acao.equalsIgnoreCase("gerar")) {
-			/*Gerando CPF Aleatorio*/
-			 cpf = geradorCpfService.gerarCpfAleatorio(uf,pontuacao);
-			redirectAttributes.addFlashAttribute("cpf", cpf);
-		
-		}else if (acao.equalsIgnoreCase("validar")) {
-			/*Validando digitos do cpf*/
-			Map<String, String> cpfDados = geradorCpfService.gerarDigitosCpf(cpfDigitado, pontuacao);
-			redirectAttributes.addFlashAttribute("cpf", cpfDados.get("cpf"));
-			
-			//testando se o cpf digitado é valido
-			if(cpfDados.get("isModificado").equalsIgnoreCase("true")) {
-				redirectAttributes.addFlashAttribute("msgvalido", "O CPF informado estava com os dígitos "
-						+ "incorretos, então ajustamos isso para você!");
-			}else {
-				redirectAttributes.addFlashAttribute("msgvalido","O CPF informado está correto!");
-			}
-		}
+	
+	    CpfResultDTO result = geradorCpfService.gerarCpfDTO(acao, cpfDigitado, uf, pontuacao);
+
+	    redirectAttributes.addFlashAttribute("cpf", result.cpf());
+	    redirectAttributes.addFlashAttribute("msgvalido", result.msgResult());
 		return "redirect:/";
 	}
 }

--- a/src/main/java/br/com/sodresoftwares/geradorcpf/model/CpfResultDTO.java
+++ b/src/main/java/br/com/sodresoftwares/geradorcpf/model/CpfResultDTO.java
@@ -1,0 +1,4 @@
+package br.com.sodresoftwares.geradorcpf.model;
+
+public record CpfResultDTO(String cpf, String msgResult) {
+}

--- a/src/main/java/br/com/sodresoftwares/geradorcpf/service/GeradorCpfService.java
+++ b/src/main/java/br/com/sodresoftwares/geradorcpf/service/GeradorCpfService.java
@@ -1,81 +1,94 @@
 package br.com.sodresoftwares.geradorcpf.service;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Random;
 
 import org.springframework.stereotype.Service;
 
+import br.com.sodresoftwares.geradorcpf.model.CpfResultDTO;
+
 @Service
 public class GeradorCpfService {
-	public String gerarCpfAleatorio(String uf,String pontuacao) {
-		//Gerando cpf aleatorio
+
+	public CpfResultDTO gerarCpfDTO(String acao, String cpfDigitado, String uf, String pontuacao) {
+		if (acao.equalsIgnoreCase("gerar")) {
+			return gerarCpfAleatorio(uf, pontuacao);
+		} else if (acao.equalsIgnoreCase("validar")) {
+			return validaCpf(cpfDigitado, pontuacao);
+		} else {
+			return new CpfResultDTO("", "Erro ao tentar executar ação. Tente novamente");
+		}
+	}
+
+	public CpfResultDTO gerarCpfAleatorio(String uf, String pontuacao) {
+		// Gerando cpf aleatorio
 		Random randon = new Random();
 		StringBuilder cpf = new StringBuilder();
-		for(int x = 0; x < 8; x++) {
-				cpf.append(randon.nextInt(10));	
+		for (int x = 0; x < 8; x++) {
+			cpf.append(randon.nextInt(10));
 		}
-		//Verificando se o usuario escolheu alguma UF
-		if(Character.getNumericValue(uf.charAt(0)) > 0) {
+		// Verificando se o usuario escolheu alguma UF
+		if (Character.getNumericValue(uf.charAt(0)) > 0) {
 			cpf.append(uf);
-		}else {
-			cpf.append(randon.nextInt(10));	
+		} else {
+			cpf.append(randon.nextInt(10));
 		}
-		String cpfCompleto = validaCpf(cpf.toString());
+		String cpfCompleto = gerarDigitosCpf(cpf.toString());
 		cpfCompleto = gerarPontuacao(cpfCompleto, pontuacao);
-		return cpfCompleto;
+		return new CpfResultDTO(cpfCompleto, "");
 	}
-	
-	public String validaCpf(String cpf) {
+
+	public String gerarDigitosCpf(String cpf) {
 		int somaTotal = 0;
 		int pos = 10;
 		int primeiroDigVerif;
 		int segundoDigVerif;
 
-		//Calculando primeiro digito
-		for(int x = 0; x < 9; x++) {
-			 somaTotal += (Character.getNumericValue(cpf.charAt(x)) * pos--);
+		// Calculando primeiro digito
+		for (int x = 0; x < 9; x++) {
+			somaTotal += (Character.getNumericValue(cpf.charAt(x)) * pos--);
 		}
 		primeiroDigVerif = 11 - (somaTotal % 11);
-		if(primeiroDigVerif >= 10) {
+		if (primeiroDigVerif >= 10) {
 			primeiroDigVerif = 0;
 		}
-		
-		//Calculando segundo digito verificador
+
+		// Calculando segundo digito verificador
 		somaTotal = 0;
 		pos = 11;
-		for(int x = 0; x < 9; x++) {
-			 somaTotal += (Character.getNumericValue(cpf.charAt(x)) * pos--);
+		for (int x = 0; x < 9; x++) {
+			somaTotal += (Character.getNumericValue(cpf.charAt(x)) * pos--);
 		}
 		somaTotal += (primeiroDigVerif * 2);
 		segundoDigVerif = 11 - (somaTotal % 11);
-		if(segundoDigVerif >= 10) {
+		if (segundoDigVerif >= 10) {
 			segundoDigVerif = 0;
 		}
-		
-		//Adicionando digitos ao corpo do cpf
-		cpf = cpf+""+(primeiroDigVerif)+""+(segundoDigVerif);
+
+		// Adicionando digitos ao corpo do cpf
+		cpf = cpf + "" + (primeiroDigVerif) + "" + (segundoDigVerif);
 		return cpf;
 	}
-	
-	public Map<String, String> gerarDigitosCpf(String cpf,String pontuacao) {
 
-		//validando cpf
-		String cpfGerado = validaCpf(cpf.substring(0,9));
-		//verificando se foi modificado
-		boolean isModificado = !cpfGerado.equalsIgnoreCase(cpf);
+	public CpfResultDTO validaCpf(String cpf, String pontuacao) {
+		//Gerando digitos
+		String cpfGerado = gerarDigitosCpf(cpf.substring(0, 9));
+		// verificando se o cpf é validado
+		String msgResult;
+		if (cpfGerado.equalsIgnoreCase(cpf)) {
+			msgResult = "O CPF informado está correto!";
+		} else {
+			msgResult = "O CPF informado estava com os dígitos incorretos, então ajustamos isso para você!";
+		}
+		// Aplicando pontuacao se necessario
 		cpfGerado = gerarPontuacao(cpfGerado, pontuacao);
-		//Mapeando dados do cpf
-		Map<String, String> cpfDados = new HashMap<>();
-		cpfDados.put("cpf", cpfGerado);
-		cpfDados.put("isModificado", String.valueOf(isModificado));
-		
-		return cpfDados;
+		// Montando DTO
+		return new CpfResultDTO(cpfGerado, msgResult);
 	}
-	
+
 	public String gerarPontuacao(String cpf, String pontuacao) {
-		if(pontuacao.equalsIgnoreCase("sim")) {
-			return  cpf.substring(0, 3)+"."+cpf.substring(3, 6)+ "."+cpf.substring(6, 9)+"."+cpf.substring(9, 11);
+		if (pontuacao.equalsIgnoreCase("sim")) {
+			return cpf.substring(0, 3) + "." + cpf.substring(3, 6) + "." + cpf.substring(6, 9) + "."
+					+ cpf.substring(9, 11);
 		}
 		return cpf;
 	}


### PR DESCRIPTION
- Adicionado CpfResultDTO (record/classe) para padronizar resposta.
- Adicionado GeradorCpfService.gerarCpfDTO(acao, cpf, uf, pontuacao).
- Removido uso de Map<String,String> para passar dados entre controller/service.
- Controller atualizado para usar RedirectAttributes com o DTO retornado.
- Pequenas correções de validação e proteção contra substring inválido.